### PR TITLE
Use progress bar to display scraping progress

### DIFF
--- a/scrape/Cargo.toml
+++ b/scrape/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 cargo-tally = { path = ".." }
 rayon = "0.9"
+indicatif = "0.8"

--- a/scrape/src/main.rs
+++ b/scrape/src/main.rs
@@ -5,6 +5,11 @@ extern crate rayon;
 use rayon::Scope;
 
 use std::env;
+use std::sync::Arc;
+
+extern crate indicatif;
+use indicatif::{ProgressBar, ProgressStyle};
+
 
 mod unwrap;
 use unwrap::DisplayUnwrap;
@@ -15,24 +20,39 @@ fn main() {
     env::set_var("ALLOW_DOWNLOAD", "");
     let config = rayon::Configuration::new().num_threads(THREADS);
     rayon::initialize(config).unwrap();
-    rayon::scope(init_index);
+    let pb = Arc::new(ProgressBar::new(total_crates().unwrap() as u64));
+
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("[{wide_bar:.cyan/blue}] {percent}% elapsed: {elapsed_precise} eta: {eta_precise}")
+            .progress_chars("&&."),
+    );
+
+    {
+        let pb = pb.clone();
+        rayon::scope(move |s| init_index(s, pb));
+    }
+    pb.finish_and_clear();
 }
 
-fn init_index(s: &Scope) {
+fn init_index(s: &Scope, pb: Arc<ProgressBar>) {
     let npages = num_pages().display_unwrap();
     for p in 1..npages + 1 {
+        let pb = pb.clone();
         s.spawn(move |s| {
             let page = cache_index(p).display_unwrap();
-            init_page(s, &page);
+            init_page(s, &page, pb);
         });
     }
 }
 
-fn init_page(s: &Scope, page: &IndexPage) {
+fn init_page(s: &Scope, page: &IndexPage, pb: Arc<ProgressBar>) {
     for krate in &page.crates {
         let name = krate.name.clone();
+        let pb = pb.clone();
         s.spawn(move |s| {
             let k = cache_crate(&name).display_unwrap();
+            pb.inc(1);
             init_crate(s, &k);
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,10 @@ pub fn num_pages() -> Result<usize, Error> {
     Ok((total + PER_PAGE - 1) / PER_PAGE)
 }
 
+pub fn total_crates() -> Result<usize, Error> {
+    Ok(cache_index(1)?.meta.total)
+}
+
 #[derive(Debug, Fail)]
 #[fail(display = "download did not return success: {}", url)]
 struct DownloadError {
@@ -220,8 +224,6 @@ where
     let mut url = Url::parse("https://crates.io").unwrap().join(endpoint)?;
     url.query_pairs_mut()
         .append_pair("per_page", &PER_PAGE.to_string());
-
-    println!("{}", url);
 
     let mut resp = retry(|| {
         let resp = reqwest::get(url.clone())?;


### PR DESCRIPTION
Unfortunately, this isn't 100% accurate - the progress bar is
incremented for a crate before all of its versions have been fetched.

Rayon provides no way of running callbacks when scoped tasks complete,
and indicatif doesn't allow us to atomically increase the progress bar
length. Unless either of these crates expands their API, this is the
best we can do.

In practice, this doesn't end up mattering that much - it manifests
itself as the progressbar briefly hanging at 100%. Unless we're very
unlucky, most of the version-fetcing tasks should have run by this
point, so we won't be waiting for very long.