### PR TITLE
Precompute transitive dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.rs.bk
+.vscode
 /graphs/
 tally.json*
 computed.json*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 **/*.rs.bk
 /graphs/
-/tally.json
-/tally.json.gz
+tally.json*
+computed.json*
+mini.json*
+comped.json*
+not.json*
 target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-tally"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -247,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cratesio-index"
 version = "0.0.0"
 dependencies = [
- "cargo-tally 0.2.9",
+ "cargo-tally 0.2.10",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "gnuplot 0.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "palette 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -220,7 +220,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,12 +249,20 @@ version = "0.0.0"
 dependencies = [
  "cargo-tally 0.2.10",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gnuplot 0.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "palette 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pre-calc 0.1.0",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -351,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -464,7 +472,7 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -486,7 +494,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -548,7 +556,7 @@ dependencies = [
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -773,7 +781,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1018,6 +1026,27 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pre-calc"
+version = "0.1.0"
+dependencies = [
+ "cargo-tally 0.2.10",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gnuplot 0.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "palette 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string-interner 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1214,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,7 +1299,7 @@ dependencies = [
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1590,7 +1641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1601,7 +1652,7 @@ dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1642,7 +1693,7 @@ dependencies = [
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1769,7 +1820,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1901,7 +1952,7 @@ dependencies = [
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
-"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -1955,6 +2006,8 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
+"checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tally"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Cargo subcommand for drawing graphs of the number of direct dependencies on a crate over time"

--- a/index/.gitignore
+++ b/index/.gitignore
@@ -1,2 +1,8 @@
-/tally.json
-/tally.json.gz
+**/*.rs.bk
+/graphs/
+tally.json*
+computed.json*
+mini.json*
+comped.json*
+not.json
+target/

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -8,12 +8,21 @@ publish = false
 [dependencies]
 cargo-tally = { path = ".." }
 chrono = { version = "0.4", features = ["serde"] }
+env_logger = "0.6"
 flate2 = "1.0"
+fnv = "1.0"
 git2 = "0.8"
 indicatif = "0.11"
 lazy_static = "1.3"
+log = "0.4.8"
 regex = "1.1"
 semver = "0.9"
+semver-parser = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.2"
+
+rayon = "1.2.0"
+pre-calc = { path= "../pre-calc" }
+gnuplot = "0.0.31"
+palette = "0.4"

--- a/index/src/error.rs
+++ b/index/src/error.rs
@@ -1,9 +1,8 @@
 use semver::ReqParseError;
 
-use std::fmt::{self, Display, Debug};
+use std::fmt::{self, Debug, Display};
 use std::io;
 use std::path::PathBuf;
-
 
 pub enum Error {
     ParseSeries(String, ReqParseError),
@@ -11,7 +10,6 @@ pub enum Error {
     JsonLine(PathBuf, serde_json::Error),
     Json(serde_json::Error),
     Io(io::Error),
-    
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/index/src/error.rs
+++ b/index/src/error.rs
@@ -1,12 +1,17 @@
-use std::fmt::{self, Display};
+use semver::ReqParseError;
+
+use std::fmt::{self, Display, Debug};
 use std::io;
 use std::path::PathBuf;
 
+
 pub enum Error {
+    ParseSeries(String, ReqParseError),
     Git2(git2::Error),
     JsonLine(PathBuf, serde_json::Error),
     Json(serde_json::Error),
     Io(io::Error),
+    
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -20,7 +25,13 @@ impl Display for Error {
             JsonLine(path, e) => write!(f, "{}: {}", path.display(), e),
             Json(e) => write!(f, "{}", e),
             Io(e) => write!(f, "{}", e),
+            ParseSeries(s, err) => write!(f, "failed to parse series {}: {}", s, err),
         }
+    }
+}
+impl Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -148,7 +148,8 @@ fn load_computed(pb: &ProgressBar, file: &str) -> Result<Vec<TranitiveDep>> {
     pb.inc(1);
 
     let file = fs::File::open(json_path)?;
-    let mut decoder = GzDecoder::new(file);
+    let mut buf = std::io::BufReader::new(file);
+    let mut decoder = GzDecoder::new(buf);
     let mut decompressed = String::new();
     decoder.read_to_string(&mut decompressed)?; 
 

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -68,8 +68,10 @@ fn try_main() -> Result<()> {
         .into_iter()
         .filter(|row| matching_crates(row, &searching))
         .collect::<Vec<_>>();
+    println!("FINISHED FILTER");
+    draw_graph(&searching, table.as_ref());
 
-    // let v_req_1 = VersionReq::parse("1.0").expect("version req fail");
+      // let v_req_1 = VersionReq::parse("1.0").expect("version req fail");
     // let mut v1_total = 1;
     // let mut v07_total = 1;
     // table.retain(|k| {
@@ -93,8 +95,6 @@ fn try_main() -> Result<()> {
     //         return is_range;
     //     }
     // });
-    println!("FINISHED FILTER");
-    draw_graph(&searching, table.as_ref());
 
     // let crates = test(f_in)?;
     // let pb = setup_progress_bar(crates.len());

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -75,8 +75,6 @@ fn try_main() -> Result<()> {
     draw_graph(&searching, table.as_ref());
 
     // let mut crates = test(f_in)?;
-    // // TODO this might not be needed
-    // crates.par_sort_by(|a, b| a.published.cmp(&b.published));
     // let pb = setup_progress_bar(crates.len());
     // pb.set_message("Computing direct and transitive dependencies");
     // let mut krates = pre_compute_graph(crates, &pb);
@@ -103,7 +101,7 @@ fn test(file: &str) -> Result<Vec<Crate>> {
     let mut decompressed = String::new();
     decoder.read_to_string(&mut decompressed)?; 
 
-    let mut krates = decompressed
+    let krates = decompressed
         .par_lines()
         .inspect(|_| pb.inc(1))
         .map(|line| {
@@ -161,8 +159,6 @@ fn load_computed(pb: &ProgressBar, file: &str) -> Result<Vec<TranitiveDep>> {
         .collect::<Vec<_>>();
     // windows filter skips first item
     filtered.insert(0,krates[0].clone());
-    //TODO do this in one place and make sure its not scrambled when json serialized
-    filtered.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
     pb.finish_and_clear();
     Ok(filtered)
 }

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -1,29 +1,35 @@
 mod dir;
 mod error;
 
-use cargo_tally::Crate;
+use cargo_tally::{TranitiveDep, Crate};
 use chrono::{NaiveDateTime, Utc};
 use flate2::write::GzEncoder;
+use flate2::read::GzDecoder;
 use flate2::Compression;
 use git2::{Commit, Repository};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use lazy_static::lazy_static;
+use pre_calc::{Row, crate_name, pre_compute_graph, CrateName};
 use regex::Regex;
-use semver::Version;
+use semver::{Version, VersionReq};
+use semver_parser::range::{self, Op::Compatible, Predicate};
 use structopt::StructOpt;
+
+use rayon::prelude::*;
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap as Map;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Write, Read};
 use std::path::{Path, PathBuf};
-use std::process;
 
 use crate::error::{Error, Result};
 
 const TIPS: [&str; 2] = ["origin/master", "origin/snapshot-2018-09-26"];
 
 type DateTime = chrono::DateTime<Utc>;
+
+// 139_079 crates in crates.io
 
 #[derive(StructOpt, Debug)]
 struct Opts {
@@ -32,23 +38,170 @@ struct Opts {
     index: PathBuf,
 }
 
+#[derive(Debug)]
+struct Matcher<'a> {
+    name: &'a str,
+    req: VersionReq,
+    nodes: Vec<u32>,
+}
+
 fn main() {
     if let Err(err) = try_main() {
         let _ = writeln!(io::stderr(), "Error: {}", err);
-        process::exit(1);
+        std::process::exit(1);
     }
 }
 
 fn try_main() -> Result<()> {
-    let opts = Opts::from_args();
-    let repo = Repository::open(&opts.index)?;
-    let crates = parse_index(&opts.index)?;
-    let pb = setup_progress_bar(crates.len());
-    let timestamps = compute_timestamps(repo, &pb)?;
-    let crates = consolidate_crates(crates, timestamps);
-    write_json(crates)?;
+    let f_in = "../tally.json.gz";
+    let f_out = "./not.json.gz";
+
+    // let opts = Opts::from_args();
+    //let repo = Repository::open(&opts.index).expect("open rep");
+    // let crates = parse_index(&opts.index).expect("parse idx");
+    // let pb = setup_progress_bar(crates.len());
+    // let timestamps = compute_timestamps(repo, &pb)?;
+    // let crates = consolidate_crates(crates, timestamps);
+
+    let pb = setup_progress_bar(3_168_028);
+    let searching = ["tar"];
+    // load_computed sorts array
+    let table = load_computed(&pb, f_out)?
+        .into_par_iter()
+        .inspect(|_| pb.inc(1))
+        .filter(|row| matching_crates(row, &searching))
+        .collect::<Vec<_>>();
+
+    println!("FINISHED FILTER");
+
+    draw_graph(&searching, table.as_ref());
+
+    // let mut crates = test(f_in)?;
+    // // TODO this might not be needed
+    // crates.par_sort_by(|a, b| a.published.cmp(&b.published));
+    // let pb = setup_progress_bar(crates.len());
+    // pb.set_message("Computing direct and transitive dependencies");
+    // let mut krates = pre_compute_graph(crates, &pb);
+    // // sort here becasue when Vec<TransitiveDeps> is returned its out of order
+    // // from adding items at every timestamp?
+    // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    // write_json(f_out, krates)?;
+    
     pb.finish_and_clear();
     Ok(())
+}
+
+fn test(file: &str) -> Result<Vec<Crate>> {
+    let pb = setup_progress_bar(139_080);
+    pb.inc(1);
+    
+    let json_path = Path::new(file);
+    if !json_path.exists() {
+        panic!("no file {:?}", json_path)
+    }
+
+    let file = fs::File::open(json_path)?;
+    let mut decoder = GzDecoder::new(file);
+    let mut decompressed = String::new();
+    decoder.read_to_string(&mut decompressed)?; 
+
+    let mut krates = decompressed
+        .par_lines()
+        .inspect(|_| pb.inc(1))
+        .map(|line| {
+            serde_json::from_str(line)
+            .map_err(|e| {
+                panic!("{:?}", e)
+            })
+            .unwrap()
+        })
+        .collect::<Vec<Crate>>();
+    //let de = serde_json::Deserializer::from_slice(&json);
+    //let mut ret = Vec::new();
+    // for line in pb.wrap_iter(de.into_iter::<Crate>()) {
+    //     let krate = line?;
+    //     ret.push(krate);
+    // }
+    
+    pb.finish_and_clear();
+    Ok(krates)
+}
+
+/// Returns time sorted `Vec<TransitiveDep>`  
+// TODO decomp and deserialization is SLOW make obj smaller!!!
+fn load_computed(pb: &ProgressBar, file: &str) -> Result<Vec<TranitiveDep>> {
+    let json_path = Path::new(file);
+    if !json_path.exists() {
+        panic!("no file {:?}", json_path)
+    }
+ 
+    let file = fs::File::open(json_path)?;
+    let mut decoder = GzDecoder::new(file);
+    let mut decompressed = String::new();
+    decoder.read_to_string(&mut decompressed)?; 
+
+    let mut krates = decompressed
+        .par_lines()
+        .inspect(|_| pb.inc(1))
+        .map(|line| {
+            serde_json::from_str(line)
+            .map_err(|e| {
+                panic!("{:?}", e)
+            })
+            .unwrap()
+        })
+        .collect::<Vec<TranitiveDep>>();
+    // let de = serde_json::Deserializer::from_slice(&decompressed);
+    // let mut krates = Vec::new();
+    // for line in pb.wrap_iter(de.into_iter::<TransitiveDep>()) {
+    //     let krate = line?;
+    //     krates.push(krate);
+    // }
+
+    krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    pb.finish_and_clear();
+    Ok(krates)
+}
+
+fn create_matchers(search: &str) -> Result<Matcher> {
+    let mut pieces = search.splitn(2, ':');
+    let matcher = Matcher {
+        name: pieces.next().unwrap(),
+        req: match pieces.next().unwrap_or("*").parse() {
+            Ok(req) => req,
+            Err(err) => return Err(Error::ParseSeries(search.to_string(), err)),
+        },
+        nodes: Vec::new(),
+    };
+
+    Ok(matcher)
+}
+
+fn compatible_req(version: &Version) -> VersionReq {
+    use semver::Identifier as SemverId;
+    use semver_parser::version::Identifier as ParseId;
+    VersionReq::from(range::VersionReq {
+        predicates: vec![Predicate {
+            op: Compatible,
+            major: version.major,
+            minor: Some(version.minor),
+            patch: Some(version.patch),
+            pre: version
+                .pre
+                .iter()
+                .map(|pre| match *pre {
+                    SemverId::Numeric(n) => ParseId::Numeric(n),
+                    SemverId::AlphaNumeric(ref s) => ParseId::AlphaNumeric(s.clone()),
+                })
+                .collect(),
+        }],
+    })
+}
+
+fn matching_crates(krate: &TranitiveDep, search: &[&str]) -> bool {
+    search.iter()
+        .map(|&s| create_matchers(s).expect("failed to parse"))
+        .any(|matcher| matcher.name == krate.name && matcher.req.matches(&krate.version))
 }
 
 fn parse_index(index: &Path) -> Result<Vec<Crate>> {
@@ -73,7 +226,7 @@ fn setup_progress_bar(len: usize) -> ProgressBar {
     let pb = ProgressBar::new(len as u64);
     let style = ProgressStyle::default_bar()
         .template("[{wide_bar:.cyan/blue}] {percent}%")
-        .progress_chars("&&.");
+        .progress_chars("=>.");
     pb.set_style(style);
     pb.set_draw_target(ProgressDrawTarget::stderr());
     pb
@@ -161,7 +314,7 @@ fn consolidate_crates(crates: Vec<Crate>, timestamps: Timestamps) -> Vec<Crate> 
     crates
 }
 
-fn write_json(crates: Vec<Crate>) -> Result<()> {
+fn write_json<T: serde::Serialize>(file: &str, crates: Vec<T>) -> Result<()> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
 
     for krate in crates {
@@ -171,7 +324,7 @@ fn write_json(crates: Vec<Crate>) -> Result<()> {
     }
 
     let gz = encoder.finish()?;
-    fs::write(cargo_tally::JSONFILE, gz)?;
+    fs::write(file, gz)?;
     Ok(())
 }
 
@@ -211,5 +364,105 @@ fn classify_commit(commit: &Commit) -> CommitType {
         CommitType::Unyank
     } else {
         CommitType::Manual
+    }
+}
+
+
+use gnuplot::{
+    AlignLeft, AlignTop, Auto, AxesCommon, Caption, Color, Figure, Fix, Graph, LineWidth,
+    MajorScale, Placement,
+};
+use chrono::{NaiveDate, NaiveTime};
+use palette;
+use palette::{Hue, Srgb};
+
+fn version_match(ver: &str, row: &TranitiveDep) -> bool {
+    if let Some(ver) = ver.split(':').nth(1) {
+        let pin_req = format!("^{}", ver);
+        let ver_req = VersionReq::parse(&pin_req).expect("version match");
+        ver_req.matches(&row.version)
+    } else {
+        println!("SHOULD NOT SEE FOR NOW");
+        true
+    }
+    
+}
+
+fn draw_graph(krates: &[&str], table: &[TranitiveDep]) {
+    
+    let mut colors = Vec::new();
+    let mut captions = Vec::new();
+    let primary: palette::Color = Srgb::new(217u8, 87, 43).into_format().into_linear().into();
+    let n = krates.len();
+    for i in 0..n {
+        let linear = primary.shift_hue(360.0 * ((i + 1) as f32) / (n as f32));
+        let srgb = Srgb::from_linear(linear.into()).into_format::<u8>();
+        let hex = format!("#{:02X}{:02X}{:02X}", srgb.red, srgb.green, srgb.blue);
+        colors.push(hex);
+        captions.push(krates[i].replace('_', "\\\\_"));
+    }
+
+    let mut fg = Figure::new();
+    {
+        // Create plot
+        let axes = fg.axes2d();
+        axes.set_title(&format!("testing {} transitive deps", krates[0]), &[]);
+        axes.set_x_range(
+            Fix(float_year(&table[0].timestamp) - 0.3),
+            Fix(float_year(&Utc::now()) + 0.15),
+        );
+        axes.set_y_range(Fix(0.0), Auto);
+        axes.set_x_ticks(Some((Fix(1.0), 12)), &[MajorScale(2.0)], &[]);
+        axes.set_legend(
+            Graph(0.05),
+            Graph(0.9),
+            &[Placement(AlignLeft, AlignTop)],
+            &[],
+        );
+
+        // Create x-axis
+        // let mut x = Vec::new();
+        // for row in table {
+            
+        // }
+
+        // Create series
+        for i in 0..n {
+            let mut y = Vec::new();
+            let mut x = Vec::new();
+            for row in table {
+
+                println!("{:?}", row);
+
+                if version_match(krates[i], row) {
+                    x.push(float_year(&row.timestamp));
+                    y.push(row.transitive_count);
+                }
+            }
+            axes.lines(
+                &x,
+                &y,
+                &[Caption(&captions[i]), LineWidth(1.5), Color(&colors[i])],
+            );
+        }
+    }
+    println!("TABLE LEN {}", table.len());
+    fg.show();
+}
+fn float_year(dt: &DateTime) -> f64 {
+    let nd = NaiveDate::from_ymd(2017, 1, 1);
+    let nt = NaiveTime::from_hms_milli(0, 0, 0, 0);
+    let base = DateTime::from_utc(NaiveDateTime::new(nd, nt), Utc);
+    let offset = dt.signed_duration_since(base);
+    let year = offset.num_minutes() as f64 / 525_960.0 + 2017.0;
+    year
+}
+
+mod test {
+    use super::*;
+    #[test]
+    fn run_for_output() {
+        env_logger::init();
+        super::try_main().expect("run for output failed at try_main");
     }
 }

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let f_in = "../tally.json.gz";
-    let f_out = "./not.json.gz";
+    let f_out = "./computed.json.gz";
 
     // let opts = Opts::from_args();
     //let repo = Repository::open(&opts.index).expect("open rep");
@@ -63,29 +63,27 @@ fn try_main() -> Result<()> {
     // let timestamps = compute_timestamps(repo, &pb)?;
     // let crates = consolidate_crates(crates, timestamps);
 
-    let pb = setup_progress_bar(3_168_028);
-    let searching = ["tar"];
-    // load_computed sorts array
-    let table = load_computed(&pb, f_out)?
-        .into_par_iter()
-        .inspect(|_| pb.inc(1))
-        .filter(|row| matching_crates(row, &searching))
-        .collect::<Vec<_>>();
+    // let pb = setup_progress_bar(3_168_028);
+    // let searching = ["tar"];
+    // // load_computed sorts array
+    // let table = load_computed(&pb, f_out)?
+    //     .into_par_iter()
+    //     .inspect(|_| pb.inc(1))
+    //     .filter(|row| matching_crates(row, &searching))
+    //     .collect::<Vec<_>>();
+    // println!("FINISHED FILTER");
+    // draw_graph(&searching, table.as_ref());
 
-    println!("FINISHED FILTER");
-
-    draw_graph(&searching, table.as_ref());
-
-    // let mut crates = test(f_in)?;
-    // // TODO this might not be needed
-    // crates.par_sort_by(|a, b| a.published.cmp(&b.published));
-    // let pb = setup_progress_bar(crates.len());
-    // pb.set_message("Computing direct and transitive dependencies");
-    // let mut krates = pre_compute_graph(crates, &pb);
-    // // sort here becasue when Vec<TransitiveDeps> is returned its out of order
-    // // from adding items at every timestamp?
-    // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    // write_json(f_out, krates)?;
+    let mut crates = test(f_in)?;
+    // TODO this might not be needed
+    crates.par_sort_by(|a, b| a.published.cmp(&b.published));
+    let pb = setup_progress_bar(crates.len());
+    pb.set_message("Computing direct and transitive dependencies");
+    let mut krates = pre_compute_graph(crates, &pb);
+    // sort here becasue when Vec<TransitiveDeps> is returned its out of order
+    // from adding items at every timestamp?
+    krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    write_json(f_out, krates)?;
     
     pb.finish_and_clear();
     Ok(())

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -1,15 +1,15 @@
 mod dir;
 mod error;
 
-use cargo_tally::{Crate, TranitiveDep};
+use cargo_tally::{TranitiveDep, Crate};
 use chrono::{NaiveDateTime, Utc};
-use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
+use flate2::read::GzDecoder;
 use flate2::Compression;
 use git2::{Commit, Repository};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use lazy_static::lazy_static;
-use pre_calc::{crate_name, pre_compute_graph, CrateName, Row};
+use pre_calc::{Row, crate_name, pre_compute_graph, CrateName};
 use regex::Regex;
 use semver::{Version, VersionReq};
 use semver_parser::range::{self, Op::Compatible, Predicate};
@@ -20,7 +20,7 @@ use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::collections::BTreeMap as Map;
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write, Read};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
@@ -28,8 +28,6 @@ use crate::error::{Error, Result};
 const TIPS: [&str; 2] = ["origin/master", "origin/snapshot-2018-09-26"];
 
 type DateTime = chrono::DateTime<Utc>;
-
-// 139_079 crates in crates.io
 
 #[derive(StructOpt, Debug)]
 struct Opts {
@@ -81,7 +79,7 @@ fn try_main() -> Result<()> {
     // // from adding items at every timestamp
     // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
     // write_json(f_out, krates)?;
-
+    
     pb.finish_and_clear();
     Ok(())
 }
@@ -89,7 +87,7 @@ fn try_main() -> Result<()> {
 fn test(file: &str) -> Result<Vec<Crate>> {
     let pb = setup_progress_bar(139_080);
     pb.inc(1);
-
+    
     let json_path = Path::new(file);
     if !json_path.exists() {
         panic!("no file {:?}", json_path)
@@ -98,15 +96,17 @@ fn test(file: &str) -> Result<Vec<Crate>> {
     let file = fs::File::open(json_path)?;
     let mut decoder = GzDecoder::new(file);
     let mut decompressed = String::new();
-    decoder.read_to_string(&mut decompressed)?;
+    decoder.read_to_string(&mut decompressed)?; 
 
     let krates = decompressed
         .par_lines()
         .inspect(|_| pb.inc(1))
         .map(|line| {
             serde_json::from_str(line)
-                .map_err(|e| panic!("{:?}", e))
-                .unwrap()
+            .map_err(|e| {
+                panic!("{:?}", e)
+            })
+            .unwrap()
         })
         .collect::<Vec<Crate>>();
 
@@ -124,15 +124,17 @@ fn load_computed(pb: &ProgressBar, file: &str) -> Result<Vec<TranitiveDep>> {
     let file = fs::File::open(json_path)?;
     let mut decoder = GzDecoder::new(file);
     let mut decompressed = String::new();
-    decoder.read_to_string(&mut decompressed)?;
+    decoder.read_to_string(&mut decompressed)?; 
 
     let mut krates = decompressed
         .par_lines()
         .inspect(|_| pb.inc(1))
         .map(|line| {
             serde_json::from_str(line)
-                .map_err(|e| panic!("{:?}", e))
-                .unwrap()
+            .map_err(|e| {
+                panic!("{:?}", e)
+            })
+            .unwrap()
         })
         .collect::<Vec<TranitiveDep>>();
 
@@ -203,13 +205,12 @@ fn compatible_req(version: &Version) -> VersionReq {
 }
 
 fn matching_crates(krate: &TranitiveDep, search: &[&str]) -> bool {
-    search
-        .iter()
+    search.iter()
         .map(|&s| create_matchers(s).expect("failed to parse"))
         .any(|matcher| {
             matcher.name == krate.name
-                && matcher.req.matches(&krate.version)
-                && krate.transitive_count != 0
+            && matcher.req.matches(&krate.version)
+            && krate.transitive_count != 0
         })
 }
 
@@ -376,11 +377,12 @@ fn classify_commit(commit: &Commit) -> CommitType {
     }
 }
 
-use chrono::{NaiveDate, NaiveTime};
+
 use gnuplot::{
     AlignLeft, AlignTop, Auto, AxesCommon, Caption, Color, Figure, Fix, Graph, LineWidth,
     MajorScale, Placement,
 };
+use chrono::{NaiveDate, NaiveTime};
 use palette;
 use palette::{Hue, Srgb};
 
@@ -393,9 +395,11 @@ fn version_match(ver: &str, row: &TranitiveDep) -> bool {
         println!("SHOULD NOT SEE FOR NOW");
         true
     }
+    
 }
 
 fn draw_graph(krates: &[&str], table: &[TranitiveDep]) {
+    
     let mut colors = Vec::new();
     let mut captions = Vec::new();
     let primary: palette::Color = Srgb::new(217u8, 87, 43).into_format().into_linear().into();
@@ -439,6 +443,7 @@ fn draw_graph(krates: &[&str], table: &[TranitiveDep]) {
             let mut y = Vec::new();
             let mut x = Vec::new();
             for row in table {
+
                 println!("{:?}", row);
 
                 if version_match(krates[i], row) {

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -60,6 +60,7 @@ fn try_main() -> Result<()> {
     let pb = setup_progress_bar(crates.len());
     let timestamps = compute_timestamps(repo, &pb)?;
     let crates = consolidate_crates(crates, timestamps);
+    write_json(f_in, crates);
 
     let crates = test(f_in)?;
     let pb = setup_progress_bar(crates.len());

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -75,7 +75,7 @@ fn try_main() -> Result<()> {
     // let pb = setup_progress_bar(crates.len());
     // pb.set_message("Computing direct and transitive dependencies");
     // let mut krates = pre_compute_graph(crates, &pb);
-    // // sort here becasue when Vec<TransitiveDeps> is returned its out of order
+    // // sort here because when Vec<TransitiveDeps> is returned its out of order
     // // from adding items at every timestamp
     // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
     // write_json(f_out, krates)?;

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
-const TIPS: [&str; 2] = ["origin/master", "origin/snapshot-2018-09-26"];
+const TIPS: [&str; 3] = ["origin/master", "origin/snapshot-2018-09-26", "origin/snapshot-2019-10-17"];
 
 type DateTime = chrono::DateTime<Utc>;
 
@@ -60,7 +60,7 @@ fn try_main() -> Result<()> {
     // let pb = setup_progress_bar(crates.len());
     // let timestamps = compute_timestamps(repo, &pb)?;
     // let crates = consolidate_crates(crates, timestamps);
-
+    
     let pb = setup_progress_bar(5_448_100);
     let searching = ["serde:0.7", "serde:0.8", "serde:0.9", "serde:1.0"];
     // load_computed sorts array
@@ -70,31 +70,6 @@ fn try_main() -> Result<()> {
         .collect::<Vec<_>>();
     println!("FINISHED FILTER");
     draw_graph(&searching, table.as_ref());
-
-      // let v_req_1 = VersionReq::parse("1.0").expect("version req fail");
-    // let mut v1_total = 1;
-    // let mut v07_total = 1;
-    // table.retain(|k| {
-    //     if v_req_1.matches(&k.version) {
-    //         let is_range = if k.transitive_count != 0 { (v1_total / k.transitive_count) < 50 } else { false };
-    //         v1_total = if is_range && k.transitive_count != 0 {
-    //             k.transitive_count
-    //         } else {
-    //             println!("v1: {} krate trans: {}", v1_total, k.transitive_count);
-    //             v1_total
-    //         };
-    //         return is_range;
-    //     } else {
-    //         let is_range = if k.transitive_count != 0 { (v07_total / k.transitive_count) < 50 } else { false };
-    //         v07_total = if is_range && k.transitive_count != 0 {
-    //             k.transitive_count
-    //         } else {
-    //             println!("v1: {} krate trans: {}", v07_total, k.transitive_count);
-    //             v07_total
-    //         };
-    //         return is_range;
-    //     }
-    // });
 
     // let crates = test(f_in)?;
     // let pb = setup_progress_bar(crates.len());
@@ -131,7 +106,7 @@ fn test(file: &str) -> Result<Vec<Crate>> {
         krates.push(k);
     }
 
-    //TODO ASK WHY HORIBLE
+    // TODO ASK WHY HORIBLE
     // let krates = decompressed
     //     .par_lines()
     //     .inspect(|_| pb.inc(1))
@@ -162,19 +137,6 @@ fn load_computed(pb: &ProgressBar, file: &str) -> Result<Vec<TranitiveDep>> {
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     let de = serde_json::Deserializer::from_slice(&decompressed);
-
-    // HORIBLE
-    // let mut krates = decompressed
-    //     .par_lines()
-    //     .inspect(|_| pb.inc(1))
-    //     .map(|line| {
-    //         serde_json::from_str(line)
-    //         .map_err(|e| {
-    //             panic!("{:?}", e)
-    //         })
-    //         .unwrap()
-    //     })
-    //     .collect::<Vec<TranitiveDep>>();
 
     let mut krates = Vec::new();
     for line in de.into_iter::<TranitiveDep>() {
@@ -460,12 +422,10 @@ fn draw_graph(krates: &[&str], table: &[TranitiveDep]) {
             let mut x = Vec::new();
             for row in table {
 
-                // println!("{:?}", row);
-
-                if version_match(krates[i], row) {
+                //if version_match(krates[i], row) {
                     x.push(float_year(&row.timestamp));
                     y.push(row.transitive_count);
-                }
+                //}
             }
             axes.lines(
                 &x,
@@ -474,8 +434,7 @@ fn draw_graph(krates: &[&str], table: &[TranitiveDep]) {
             );
         }
     }
-    println!("TABLE LEN {}", table.len());
-    fg.show();
+   fg.show();
 }
 fn float_year(dt: &DateTime) -> f64 {
     let nd = NaiveDate::from_ymd(2017, 1, 1);

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -54,25 +54,24 @@ fn try_main() -> Result<()> {
     let f_in = "../tally.json.gz";
     let f_out = "./computed.json.gz";
 
-    let opts = Opts::from_args();
-    let repo = Repository::open(&opts.index).expect("open rep");
-    let crates = parse_index(&opts.index).expect("parse idx");
-    let pb = setup_progress_bar(crates.len());
-    let timestamps = compute_timestamps(repo, &pb)?;
-    let crates = consolidate_crates(crates, timestamps);
-    write_json(f_in, crates);
+    // let opts = Opts::from_args();
+    // let repo = Repository::open(&opts.index).expect("open rep");
+    // let crates = parse_index(&opts.index).expect("parse idx");
+    // let pb = setup_progress_bar(crates.len());
+    // let timestamps = compute_timestamps(repo, &pb)?;
+    // let crates = consolidate_crates(crates, timestamps);
 
-    let crates = test(f_in)?;
-    let pb = setup_progress_bar(crates.len());
-    pb.set_message("Computing direct and transitive dependencies");
-    let mut krates = pre_compute_graph(crates, &pb);
-    // sort here becasue when Vec<TransitiveDeps> is returned its out of order
-    // from adding items at every timestamp
-    krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    write_json(f_out, krates)?;
+    // let crates = test(f_in)?;
+    // let pb = setup_progress_bar(crates.len());
+    // pb.set_message("Computing direct and transitive dependencies");
+    // let mut krates = pre_compute_graph(crates, &pb);
+    // // sort here becasue when Vec<TransitiveDeps> is returned its out of order
+    // // from adding items at every timestamp
+    // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    // write_json(f_out, krates)?;
 
     let pb = setup_progress_bar(5_448_100);
-    let searching = ["serde:0.7", "serde:0.8", "serde:0.9", "serde:1.0"];
+    let searching = ["serde:0.5", "serde:0.6", "serde:0.7", "serde:0.8", "serde:0.9", "serde:1.0"];
     // load_computed sorts array
     let table = load_computed(&pb, f_out)?
         .into_par_iter()
@@ -361,7 +360,6 @@ fn version_match(ver: &str, row: &TransitiveDep) -> bool {
         println!("SHOULD NOT SEE FOR NOW");
         true
     }
-    
 }
 
 fn draw_graph(krates: &[&str], table: &[TransitiveDep]) {
@@ -406,8 +404,10 @@ fn draw_graph(krates: &[&str], table: &[TransitiveDep]) {
             let mut y = Vec::new();
             let mut x = Vec::new();
             for row in table {
-                x.push(float_year(&row.timestamp));
-                y.push(row.transitive_count);
+                if version_match(krates[i], row) {
+                    x.push(float_year(&row.timestamp));
+                    y.push(row.transitive_count);
+                }
             }
 
             axes.lines(

--- a/index/src/main.rs
+++ b/index/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let f_in = "../tally.json.gz";
-    let f_out = "./comped.json.gz";
+    let f_out = "./computed.json.gz";
 
     // let opts = Opts::from_args();
     //let repo = Repository::open(&opts.index).expect("open rep");
@@ -61,24 +61,24 @@ fn try_main() -> Result<()> {
     // let timestamps = compute_timestamps(repo, &pb)?;
     // let crates = consolidate_crates(crates, timestamps);
 
-    let pb = setup_progress_bar(5_448_100);
-    let searching = ["serde:0.8", "serde:1.0"];
-    // load_computed sorts array
-    let table = load_computed(&pb, f_out)?
-        .into_iter()
-        .filter(|row| matching_crates(row, &searching))
-        .collect::<Vec<_>>();
-    println!("FINISHED FILTER");
-    draw_graph(&searching, table.as_ref());
+    // let pb = setup_progress_bar(5_448_100);
+    // let searching = ["serde"];
+    // // load_computed sorts array
+    // let table = load_computed(&pb, f_out)?
+    //     .into_iter()
+    //     .filter(|row| matching_crates(row, &searching))
+    //     .collect::<Vec<_>>();
+    // println!("FINISHED FILTER");
+    // draw_graph(&searching, table.as_ref());
 
-    // let crates = test(f_in)?;
-    // let pb = setup_progress_bar(crates.len());
-    // pb.set_message("Computing direct and transitive dependencies");
-    // let mut krates = pre_compute_graph(crates, &pb);
-    // // sort here becasue when Vec<TransitiveDeps> is returned its out of order
-    // // from adding items at every timestamp
-    // krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    // write_json(f_out, krates)?;
+    let crates = test(f_in)?;
+    let pb = setup_progress_bar(crates.len());
+    pb.set_message("Computing direct and transitive dependencies");
+    let mut krates = pre_compute_graph(crates, &pb);
+    // sort here becasue when Vec<TransitiveDeps> is returned its out of order
+    // from adding items at every timestamp
+    krates.par_sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    write_json(f_out, krates)?;
     
     pb.finish_and_clear();
     Ok(())

--- a/pre-calc/Cargo.toml
+++ b/pre-calc/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pre-calc"
+version = "0.1.0"
+authors = ["Devin R <devin.ragotzy@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cargo-tally = {path = "../"}
+rayon = "1.2.0"
+
+chrono = { version = "0.4", features = ["serde"] }
+flate2 = "1.0"
+fnv = "1.0"
+gnuplot = "0.0.31"
+indicatif = "0.11"
+lazy_static = "1.0"
+log = "0.4"
+env_logger = "0.6"
+palette = "0.4"
+semver = { version = "0.9", features = ["serde"] }
+semver-parser = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+string-interner = "0.7"

--- a/pre-calc/Cargo.toml
+++ b/pre-calc/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 
 [dependencies]
 cargo-tally = {path = "../"}
-rayon = "1.2.0"
-
 chrono = { version = "0.4", features = ["serde"] }
 flate2 = "1.0"
 fnv = "1.0"

--- a/pre-calc/src/intern.rs
+++ b/pre-calc/src/intern.rs
@@ -1,0 +1,84 @@
+//! TODO figure how to split into files
+
+use fnv::FnvBuildHasher;
+use lazy_static::lazy_static;
+use string_interner::{StringInterner, Symbol};
+
+use std::cell::UnsafeCell;
+use std::fmt::{self, Debug, Display};
+use std::marker::PhantomData;
+use std::ops::Deref;
+
+
+lazy_static! {
+    static ref INTERN: SymbolsStayOnOneThread = Default::default();
+}
+
+struct SymbolsStayOnOneThread {
+    interner: UnsafeCell<StringInterner<CrateName, FnvBuildHasher>>,
+}
+
+impl Default for SymbolsStayOnOneThread {
+    fn default() -> Self {
+        SymbolsStayOnOneThread {
+            interner: UnsafeCell::new(StringInterner::with_hasher(Default::default())),
+        }
+    }
+}
+
+unsafe impl Send for SymbolsStayOnOneThread {}
+unsafe impl Sync for SymbolsStayOnOneThread {}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, super::Serialize, super::Deserialize)]
+pub struct CrateName {
+    value: u32,
+    not_send_sync: PhantomData<*const ()>,
+}
+
+pub fn crate_name<T: Into<String> + AsRef<str>>(string: T) -> CrateName {
+    let c = INTERN.interner.get();
+    let c = unsafe { &mut *c };
+    c.get_or_intern(string)
+}
+
+impl Symbol for CrateName {
+    fn from_usize(value: usize) -> Self {
+        CrateName {
+            value: value as u32,
+            not_send_sync: PhantomData,
+        }
+    }
+    fn to_usize(self) -> usize {
+        self.value as usize
+    }
+}
+
+impl Deref for CrateName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        let c = INTERN.interner.get();
+        unsafe {
+            let c = &*c;
+            c.resolve_unchecked(*self)
+        }
+    }
+}
+
+impl Debug for CrateName {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(&**self, formatter)
+    }
+}
+
+impl Display for CrateName {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, formatter)
+    }
+}
+
+impl<'a> PartialEq<&'a str> for CrateName {
+    fn eq(&self, other: &&str) -> bool {
+        &**self == *other
+    }
+}

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -134,9 +134,8 @@ impl Universe {
             let metadata = self.crates[&outdated.name][outdated.index as usize].clone();
             warn!("re-resolving {} {}", outdated.name, metadata.num);
 
-            // do I need to also recheck the redo crates??
-            let re_res = self.resolve_and_add_to_graph(*outdated, &metadata);
-            to_update.extend(re_res.crates.keys());
+            let _ = self.resolve_and_add_to_graph(*outdated, &metadata);
+
         }
         to_update     
     }
@@ -451,9 +450,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
                 total: row_update.total,
             };
 
-            // TransitiveDep compares all but the timestamp
             extend.insert(td);
-            //println!("{:?}", extend);
         }
     }
     table.extend(extend);

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -56,7 +56,6 @@ pub struct Row {
     pub name: CrateName,
     pub num: Version,
     // pub deps: Vec<Metadata>,
-    // TODO what to do about Vec<usize> remove for now just usize
     pub tran_counts: usize,
     pub dir_counts: usize,
     pub total: usize,
@@ -411,6 +410,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
         };
         // returns CrateKeys of all the updated crates
         let all_updated = universe.process_event(ev);
+
         let updated = all_updated
             .iter()
             .filter(|k| universe.crates.contains_key(&k.name))
@@ -455,44 +455,6 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
             extend.insert(td);
             //println!("{:?}", extend);
         }
-        
-        // // create points in time other than version releases 
-        // let index = idx as u32;
-        //     // for each version 
-        // for (i, recent_meta) in universe.crates[&name].iter().enumerate() {
-
-        //     // let key = CrateKey::new(*prev_krate, index);
-        //     let row_update = universe.compute_counts(timestamp, name, recent_meta.num.clone(), universe.crates[&name].to_vec(), i as u32);
-            
-        //     if let Some(r) = table.iter().find(|r| {
-        //         (r.transitive_count != row_update.tran_counts)
-        //             || (r.direct_count != row_update.dir_counts)
-        //             && (crate_name(&r.name) == row_update.name)
-        //             && r.version == row_update.num
-        //     }) {
-        //         let td = TranitiveDep {
-        //                 name: row_update.name.to_string(),
-        //                 timestamp,
-        //                 version: row_update.num.clone(),
-        //                 transitive_count: row_update.tran_counts,
-        //                 direct_count: row_update.dir_counts,
-        //                 total: row_update.total,
-        //             };
-        //             // TransitiveDep compares all but the timestamp
-        //             // if !extend.contains(&td) {
-        //             //     // TODO this may not be needed when running on the whole crates.io index
-        //             //     if td.transitive_count == 0 {
-        //             //         td.transitive_count = r.transitive_count;
-        //             //     }
-        //             //     if td.direct_count == 0 {
-        //             //         td.direct_count = r.direct_count;
-        //             //     }
-        //             //     println!("ADDING KRATE {:#?}", td);
-                        
-        //             // }
-        //         extend.push(td);
-        //     }
-        // }
     }
     table.extend(extend);
     table

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -451,7 +451,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
                 total: row_update.total,
             };
 
-            if &td.name == "serde" && td.transitive_count == 15 {
+            if &td.name == "serde" && (td.transitive_count == 15 || td.timestamp == cmp_time)  {
                 //println!("{:?}\n{:?}", meta, metas);
                 updated.iter().for_each(|_| {
                     if let Some(deps) = universe.reverse_depends.get(&redo_crate) {

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -1,6 +1,6 @@
 mod intern;
 
-use cargo_tally::{Dependency, DependencyKind, Feature, DateTime, TranitiveDep};
+use cargo_tally::{Dependency, DependencyKind, Feature, DateTime, TransitiveDep};
 use fnv::{FnvHashMap as Map, FnvHashSet as Set};
 use indicatif::ProgressBar;
 use log::{debug, info, warn, error};
@@ -402,7 +402,7 @@ fn compatible_req(version: &Version) -> VersionReq {
     })
 }
 
-pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveDep> {
+pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TransitiveDep> {
     let mut universe = Universe::new();
     // for each version "event" this is the set that holds version releases
     let mut table = Set::default();
@@ -431,7 +431,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
         let idx = universe.crates[&name].len() as u32 - 1;
         let row = universe.compute_counts(timestamp, name, ver, idx);
 
-        table.insert(TranitiveDep {
+        table.insert(TransitiveDep {
             name: krate.name,
             timestamp,
             version: krate.version,
@@ -457,7 +457,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
                 redo_crate.index
             );
 
-            let td = TranitiveDep {
+            let td = TransitiveDep {
                 name: row_update.name.to_string(),
                 timestamp,
                 version: row_update.num.clone(),

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -390,8 +390,8 @@ fn compatible_req(version: &Version) -> VersionReq {
 
 pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveDep> {
     let mut universe = Universe::new();
-    // for each version "event" this is the straight through vec
-    let mut table = Vec::new();
+    // for each version "event" this is the set that holds version releases
+    let mut table = Set::default();
     // for any changes that happen over time not at a version release event
     let mut extend = Set::default();
     for krate in crates {
@@ -419,7 +419,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
         let idx = universe.crates[&name].len() as u32 - 1;
         let row = universe.compute_counts(timestamp, name, ver, idx);
 
-        table.push(TranitiveDep {
+        table.insert(TranitiveDep {
             name: krate.name,
             timestamp,
             version: krate.version,
@@ -457,7 +457,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveD
         }
     }
     table.extend(extend);
-    table
+    table.into_iter().collect::<Vec<_>>()
 }
 
 #[cfg(test)]

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -439,13 +439,7 @@ pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<Transitive
             total: row.total,
         });
 
-        let key = CrateKey::new(name, idx);
-
-        let cmp_time = "2019-06-21T02:14:09-00:00".parse::<DateTime<chrono::Utc>>().expect("not a date string");
-
         for redo_crate in updated.iter() {
-            if redo_crate.name == "tar" { info!("CURRENT {} REDO {}", name, redo_crate.name) };
-
             let metas = &universe.crates[&redo_crate.name];
             let meta = &metas[redo_crate.index as usize];
 

--- a/pre-calc/src/lib.rs
+++ b/pre-calc/src/lib.rs
@@ -1,0 +1,503 @@
+mod intern;
+
+use cargo_tally::{Dependency, DependencyKind, Feature, DateTime, TranitiveDep};
+use fnv::{FnvHashMap as Map, FnvHashSet as Set};
+use indicatif::ProgressBar;
+use log::{debug, info, warn, error};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use semver::{Version, VersionReq};
+use semver_parser::range::{self, Op::Compatible, Predicate};
+
+use std::u64;
+
+pub use cargo_tally::Crate;
+pub use intern::{crate_name, CrateName};
+
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+pub struct CrateKey {
+    pub name: CrateName,
+    pub index: u32,
+}
+impl CrateKey {
+    fn new(name: CrateName, index: u32) -> Self {
+        CrateKey { name, index }
+    }
+}
+
+#[derive(Debug)]
+struct Event {
+    name: CrateName,
+    num: Version,
+    timestamp: DateTime,
+    features: Map<String, Vec<Feature>>,
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub(crate) num: Version,
+    created_at: DateTime,
+    features: Map<String, Vec<Feature>>,
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug)]
+pub struct Universe {
+    pub(crate) crates: Map<CrateName, Vec<Metadata>>,
+    pub depends: Map<CrateKey, Vec<CrateKey>>,
+    pub reverse_depends: Map<CrateKey, Set<CrateKey>>,
+    pub dir_depends: Map<CrateName, Set<CrateKey>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Row {
+    pub timestamp: DateTime,
+    pub name: CrateName,
+    pub num: Version,
+    // pub deps: Vec<Metadata>,
+    // TODO what to do about Vec<usize> remove for now just usize
+    pub tran_counts: usize,
+    pub dir_counts: usize,
+    pub total: usize,
+}
+
+impl Universe {
+    fn new() -> Self {
+        Universe {
+            crates: Map::default(),
+            depends: Map::default(),
+            reverse_depends: Map::default(),
+            dir_depends: Map::default(),
+        }
+    }
+
+    fn process_event(&mut self, event: Event) -> Vec<CrateKey> {
+        debug!("processing event {} {}", event.name, event.num);
+
+        let mut redo = Set::default();
+        if let Some(prev) = self.crates.get(&event.name) {
+            // events CrateName and index into Metadata in Universe.crates
+            let prev_key = CrateKey::new(event.name, prev.len() as u32 - 1);
+
+            for dep in &self.depends[&prev_key] {
+                self.reverse_depends.get_mut(dep).unwrap().remove(&prev_key);
+            }
+
+            self.depends.remove(&prev_key);
+            for (i, metadata) in prev.iter().enumerate() {
+                // if event lies within 
+                if compatible_req(&metadata.num).matches(&event.num) {
+                    let key = CrateKey::new(event.name, i as u32);
+                    for node in self.reverse_depends[&key].clone() {
+                        for dep in &self.depends[&node] {
+                            self.reverse_depends.get_mut(dep).unwrap().remove(&node);
+                        }
+                        redo.insert(node);
+                    }
+                }
+            }
+        }
+
+        // Fix up silly wildcard deps by pinning them to versions compatible
+        // with the latest release of the dep
+        let mut dependencies = event.dependencies;
+        let version_max = Version::new(u64::MAX, u64::MAX, u64::MAX);
+        for dep in &mut dependencies {
+            if dep.req.matches(&version_max) {
+                let name = crate_name(&*dep.name);
+                if let Some(releases) = self.crates.get(&name) {
+                    dep.req = compatible_req(&releases.last().unwrap().num);
+                }
+            }
+        }                 
+        let metadata = Metadata {
+            num: event.num,
+            created_at: event.timestamp,
+            features: event.features,
+            dependencies,
+        };
+
+        // maybe should of used a FnvHashSet here??
+        let mut to_update = Vec::new();
+
+        // index is which dependency we mean in terms of Metadata
+        let index = self.crates.entry(event.name).or_insert_with(Vec::new).len();
+        let key = CrateKey::new(event.name, index as u32);
+
+        // the updated crates dep's and trans dep's
+        let trans_res = self.resolve_and_add_to_graph(key, &metadata);
+        to_update.extend(trans_res.crates.keys());
+
+        self.reverse_depends.insert(key, Set::default());
+        self.crates.get_mut(&event.name).unwrap().push(metadata);
+
+        for outdated in redo.iter() {
+            let metadata = self.crates[&outdated.name][outdated.index as usize].clone();
+            warn!("re-resolving {} {}", outdated.name, metadata.num);
+
+            // do I need to also recheck the redo crates??
+            let re_res = self.resolve_and_add_to_graph(*outdated, &metadata);
+            to_update.extend(re_res.crates.keys());
+        }
+        to_update     
+    }
+
+    fn resolve(&self, name: &str, req: &VersionReq) -> Option<u32> {
+        self.crates
+            .get(&crate_name(name))?
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|&(_, metadata)| req.matches(&metadata.num))
+            .map(|(i, _)| i as u32)
+    }
+
+    fn resolve_and_add_to_graph(&mut self, key: CrateKey, metadata: &Metadata) -> Resolve {
+        let mut d_resolve = Resolve { crates: Map::default(), };
+        let mut t_resolve = Resolve { crates: Map::default(), };
+
+        for dep in metadata.dependencies.iter() {
+            // if the crate is in Universe.crates at the right version number
+            if let Some(index) = self.resolve(&dep.name, &dep.req) {
+                let name = crate_name(&dep.name);
+                let key = CrateKey { name, index, };
+                // direct deps just insert
+                d_resolve.crates.insert(key, ResolvedCrate::no_resolve());
+                // transitive dependencies RECURSIVELY walk deps of deps ect.
+                t_resolve.add_crate(self, key, dep.default_features, &dep.features);
+            }
+        }
+        // add `CrateKey`s of resolved crates, walks the graph and checks features 
+        // transitive deps
+        for dep in t_resolve.crates.keys() {
+            self.reverse_depends
+                .entry(*dep)
+                .or_insert_with(Set::default)
+                .insert(key);
+        }
+        // calculate direct deps too
+        for dep in d_resolve.crates.keys() {
+            self.dir_depends
+                .entry(dep.name)
+                .or_insert_with(Set::default)
+                .insert(key);
+        }
+        
+        self.depends
+            .insert(key, t_resolve.crates.keys().cloned().collect());
+        t_resolve
+    }
+
+    fn compute_counts(
+        &self,
+        timestamp: DateTime,
+        name: CrateName,
+        num: Version,
+        index: u32,
+    ) -> Row {
+        let mut set = Set::default();
+        Row {
+            timestamp,
+            name,
+            num,
+            tran_counts: {
+                    set.clear();
+                    let key = CrateKey::new(name, index);
+                    if let Some(deps) = self.reverse_depends.get(&key) {
+                        set.extend(deps.iter().map(|key| key.name));
+                        set.len()
+                    } else {
+                        0
+                    }
+                },
+            dir_counts: {
+                    set.clear();
+                    if let Some(deps) = self.dir_depends.get(&name) {
+                        set.extend(deps.iter().map(|key| key.name));
+                        set.len()
+                    } else {
+                        0
+                    }
+                },
+            total: self.crates.len(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Resolve {
+    crates: Map<CrateKey, ResolvedCrate>,
+}
+#[derive(Debug)]
+struct ResolvedCrate {
+    features: Set<String>,
+    resolved: Vec<Option<u32>>,
+}
+impl ResolvedCrate {
+    fn no_resolve() -> Self {
+        ResolvedCrate {
+            features: Set::default(),
+            resolved: Vec::new(),
+        }
+    }
+}
+impl Resolve {
+    #![allow(clippy::map_entry)]
+    fn add_crate(
+        &mut self,
+        universe: &Universe,
+        key: CrateKey,
+        default_features: bool,
+        features: &[String],
+    ) {
+        let metadata = &universe.crates[&key.name][key.index as usize];
+        debug!("adding crate {} {}", key.name, metadata.num);
+        // if not in Resolve.crates iter deps to find index of meta for each
+        if !self.crates.contains_key(&key) {
+            // array of indexs for universe.crates
+            let resolved = metadata
+                .dependencies
+                .iter()
+                .map(|dep| universe.resolve(&dep.name, &dep.req))
+                .collect::<Vec<_>>();
+                
+            self.crates.insert(
+                key,
+                ResolvedCrate {
+                    features: Set::default(),
+                    resolved: resolved.clone(),
+                },
+            );
+            for (dep, index) in metadata.dependencies.iter().zip(resolved) {
+                if !dep.optional && dep.kind != DependencyKind::Dev && index.is_some() {
+                    let key2 = CrateKey::new(crate_name(&*dep.name), index.unwrap());                    
+                    self.add_crate(universe, key2, dep.default_features, &dep.features);
+                }
+            }
+        }
+
+        if default_features {
+            if let Some(default_features) = metadata.features.get("default") {
+                for feature in default_features {
+                    self.add_dep_or_crate_feature(universe, key, feature);
+                }
+            }
+        }
+        for feature in features {
+            self.add_crate_feature(universe, key, feature);
+        }
+    }
+
+    fn add_dep_or_crate_feature(&mut self, universe: &Universe, key: CrateKey, feature: &Feature) {
+        let metadata = &universe.crates[&key.name][key.index as usize];
+
+        debug!(
+            "adding dep or feature {} {}:{}",
+            key.name, metadata.num, feature
+        );
+
+        match *feature {
+            Feature::Current(ref feature) => {
+                self.add_crate_feature(universe, key, feature);
+            }
+            Feature::Dependency(ref name, ref feature) => {
+                for (i, dep) in metadata.dependencies.iter().enumerate() {
+                    if dep.name == *name {
+                        if !self.crates.contains_key(&key) {
+                            println!("uh-oh");
+                        }
+                        if let Some(resolved) = self.crates[&key].resolved[i] {
+                            let key = CrateKey::new(crate_name(&**name), resolved);
+                            self.add_crate(universe, key, dep.default_features, &dep.features);
+                            self.add_crate_feature(universe, key, feature);
+                        }
+                        return;
+                    }
+                }
+                // FIXME https://github.com/dtolnay/cargo-tally/issues/22
+                /*
+                panic!(
+                    "feature not found: {} {}:{}/{}",
+                    key.name, metadata.num, name, feature
+                );
+                */
+            }
+        }
+    }
+
+    fn add_crate_feature(&mut self, universe: &Universe, key: CrateKey, feature: &str) {
+        let metadata = &universe.crates[&key.name][key.index as usize];
+
+        if !self
+            .crates
+            .get_mut(&key)
+            .unwrap()
+            .features
+            .insert(feature.to_owned())
+        {
+            return;
+        }
+
+        debug!("adding feature {} {}:{}", key.name, metadata.num, feature);
+
+        if let Some(subfeatures) = metadata.features.get(feature) {
+            for subfeature in subfeatures {
+                self.add_dep_or_crate_feature(universe, key, subfeature);
+            }
+        } else {
+            for (i, dep) in metadata.dependencies.iter().enumerate() {
+                if dep.name == feature {
+                    if !self.crates.contains_key(&key) {
+                        println!("uh-oh");
+                    }
+                    if let Some(resolved) = self.crates[&key].resolved[i] {
+                        let key = CrateKey::new(crate_name(feature), resolved);
+                        self.add_crate(universe, key, dep.default_features, &dep.features);
+                    }
+                    return;
+                }
+            }
+            if key.name == "libc" && metadata.num == Version::new(0, 2, 4) && feature == "no-std" {
+                // Looks like a one-time glitch, jemalloc-sys 0.1.0 depends on
+                // this nonexistent feature of libc 0.2.4.
+                return;
+            }
+            // We get here if someone made a breaking change by removing a feature :(
+        }
+    }
+}
+
+fn compatible_req(version: &Version) -> VersionReq {
+    use semver::Identifier as SemverId;
+    use semver_parser::version::Identifier as ParseId;
+    VersionReq::from(range::VersionReq {
+        predicates: vec![Predicate {
+            op: Compatible,
+            major: version.major,
+            minor: Some(version.minor),
+            patch: Some(version.patch),
+            pre: version
+                .pre
+                .iter()
+                .map(|pre| match *pre {
+                    SemverId::Numeric(n) => ParseId::Numeric(n),
+                    SemverId::AlphaNumeric(ref s) => ParseId::AlphaNumeric(s.clone()),
+                })
+                .collect(),
+        }],
+    })
+}
+
+pub fn pre_compute_graph(crates: Vec<Crate>, pb: &ProgressBar) -> Vec<TranitiveDep> {
+    let mut universe = Universe::new();
+    // for each version "event" this is the straight through vec
+    let mut table = Vec::new();
+    // for any changes that happen over time not at a version release event
+    let mut extend = Set::default();
+    for krate in crates {
+        pb.inc(1);
+
+        let name = crate_name(&krate.name);
+        let timestamp = krate.published.unwrap();
+        let ver = krate.version.clone();
+        
+        let ev = Event {
+            name,
+            num: krate.version.clone(),
+            timestamp,
+            features: krate.features,
+            dependencies: krate.dependencies,
+        };
+        // returns CrateKeys of all the updated crates
+        let updated = universe.process_event(ev);
+
+        let idx = universe.crates[&name].len() as u32 - 1;
+        let row = universe.compute_counts(timestamp, name, ver, idx);
+
+        table.push(TranitiveDep {
+            name: krate.name,
+            timestamp,
+            version: krate.version,
+            transitive_count: row.tran_counts,
+            direct_count: row.dir_counts,
+            total: row.total,
+        });
+
+        for redo_crate in updated.iter() {
+
+            if redo_crate.name == "tar" { info!("CURRENT {} REDO {}", name, redo_crate.name) };
+
+            let metas = &universe.crates[&redo_crate.name];
+            let meta = &metas[redo_crate.index as usize];
+
+            let row_update = universe.compute_counts(
+                timestamp,
+                redo_crate.name,
+                meta.num.clone(),
+                redo_crate.index
+            );
+
+            let td = TranitiveDep {
+                name: row_update.name.to_string(),
+                timestamp,
+                version: row_update.num.clone(),
+                transitive_count: row_update.tran_counts,
+                direct_count: row_update.dir_counts,
+                total: row_update.total,
+            };
+
+            // TransitiveDep compares all but the timestamp
+            extend.insert(td);
+            //println!("{:?}", extend);
+        }
+        
+        // // create points in time other than version releases 
+        // let index = idx as u32;
+        //     // for each version 
+        // for (i, recent_meta) in universe.crates[&name].iter().enumerate() {
+
+        //     // let key = CrateKey::new(*prev_krate, index);
+        //     let row_update = universe.compute_counts(timestamp, name, recent_meta.num.clone(), universe.crates[&name].to_vec(), i as u32);
+            
+        //     if let Some(r) = table.iter().find(|r| {
+        //         (r.transitive_count != row_update.tran_counts)
+        //             || (r.direct_count != row_update.dir_counts)
+        //             && (crate_name(&r.name) == row_update.name)
+        //             && r.version == row_update.num
+        //     }) {
+        //         let td = TranitiveDep {
+        //                 name: row_update.name.to_string(),
+        //                 timestamp,
+        //                 version: row_update.num.clone(),
+        //                 transitive_count: row_update.tran_counts,
+        //                 direct_count: row_update.dir_counts,
+        //                 total: row_update.total,
+        //             };
+        //             // TransitiveDep compares all but the timestamp
+        //             // if !extend.contains(&td) {
+        //             //     // TODO this may not be needed when running on the whole crates.io index
+        //             //     if td.transitive_count == 0 {
+        //             //         td.transitive_count = r.transitive_count;
+        //             //     }
+        //             //     if td.direct_count == 0 {
+        //             //         td.direct_count = r.direct_count;
+        //             //     }
+        //             //     println!("ADDING KRATE {:#?}", td);
+                        
+        //             // }
+        //         extend.push(td);
+        //     }
+        // }
+    }
+    table.extend(extend);
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use semver::ReqParseError;
 
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Debug};
 use std::io;
 
 pub enum Error {
@@ -32,6 +32,12 @@ impl Display for Error {
             Regex(err) => write!(f, "{}", err),
             NothingFound => write!(f, "nothing found for this crate"),
         }
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Display};
 
 pub const JSONFILE: &str = "tally.json.gz";
+pub const COMPFILE: &str = "computed.json.gz";
 
 pub type DateTime = chrono::DateTime<Utc>;
 
@@ -29,6 +30,16 @@ pub struct Dependency {
     pub default_features: bool,
     #[serde(default, deserialize_with = "null_as_default")]
     pub kind: DependencyKind,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TranitiveDep {
+    pub name: String,
+    pub timestamp: DateTime,
+    pub version: Version,
+    pub transitive_count: usize,
+    pub direct_count: usize,
+    pub total: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -81,7 +92,7 @@ impl Display for Feature {
 }
 
 impl Serialize for Feature {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub struct Dependency {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct TranitiveDep {
+pub struct TransitiveDep {
     pub name: String,
     pub timestamp: DateTime,
     pub version: Version,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
     clippy::unreadable_literal
 )]
 
+use chrono::Utc;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
@@ -20,9 +21,12 @@ mod init;
 mod intern;
 mod progress;
 mod tally;
+mod tally2;
 
 use crate::init::init;
 use crate::tally::tally;
+
+use crate::tally2::tally2;
 
 #[derive(StructOpt)]
 #[structopt(bin_name = "cargo")]
@@ -79,7 +83,7 @@ fn main() {
         process::exit(1);
     }
 
-    let result = if args.init { init() } else { tally(&args) };
+    let result = if args.init { init() } else { tally2(&args) };
 
     if let Err(err) = result {
         let _ = writeln!(io::stderr(), "{}", err);

--- a/src/tally2.rs
+++ b/src/tally2.rs
@@ -7,7 +7,6 @@ use gnuplot::{
 use indicatif::ProgressBar;
 use palette;
 use palette::{Hue, Srgb};
-use rayon::prelude::*;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +53,7 @@ fn load_computed(pb: &ProgressBar) -> Result<Vec<TranitiveDep>, io::Error> {
     decoder.read_to_string(&mut decompressed)?; 
 
     let mut krates = decompressed
-        .par_lines()
+        .lines()
         .inspect(|_| pb.inc(1))
         .map(|line| {
             serde_json::from_str(line)
@@ -72,7 +71,7 @@ fn load_computed(pb: &ProgressBar) -> Result<Vec<TranitiveDep>, io::Error> {
     // }
     pb.finish_and_clear();
 
-    krates.par_sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    krates.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
     Ok(krates)
 }
 
@@ -179,7 +178,7 @@ pub(crate) fn tally2(args: &Args) -> error::Result<()> {
     pb.set_message("FIX ME");
 
     let table = load_computed(&pb)?
-        .into_par_iter()
+        .into_iter()
         .filter(|k| matching_crates(k, &args.crates))
         .collect::<Vec<_>>();
     

--- a/src/tally2.rs
+++ b/src/tally2.rs
@@ -1,0 +1,188 @@
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use flate2::read::GzDecoder;
+use gnuplot::{
+    AlignLeft, AlignTop, Auto, AxesCommon, Caption, Color, Figure, Fix, Graph, LineWidth,
+    MajorScale, Placement,
+};
+use indicatif::ProgressBar;
+use palette;
+use palette::{Hue, Srgb};
+use rayon::prelude::*;
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+use crate::error;
+use crate::Args;
+
+type DateTime = chrono::DateTime<Utc>;
+
+// TODO This is copied from pre_calc struct is serialized in that crate and 
+// deserialized here can't import from that crate, I'm sure there 
+// is a better way to do this.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TranitiveDep {
+    pub name: String,
+    pub timestamp: DateTime,
+    pub version: Version,
+    pub transitive_count: usize,
+    pub direct_count: usize,
+    pub total: usize,
+}
+
+#[derive(Debug)]
+struct Matcher<'a> {
+    name: &'a str,
+    req: VersionReq,
+    nodes: Vec<u32>,
+}
+
+
+// TODO fix errors so uses error.rs errors
+fn load_computed(pb: &ProgressBar) -> Result<Vec<TranitiveDep>, io::Error> {
+    let json_path = Path::new("../computed.json.gz");
+    if !json_path.exists() {
+        panic!("no file {:?}", json_path)
+    }
+ 
+    let file = fs::File::open(json_path)?;
+    let mut decoder = GzDecoder::new(file);
+    let mut decompressed = String::new();
+    decoder.read_to_string(&mut decompressed)?; 
+
+    let mut krates = decompressed
+        .par_lines()
+        .inspect(|_| pb.inc(1))
+        .map(|line| {
+            serde_json::from_str(line)
+            .map_err(|e| {
+                panic!("{:?}", e)
+            })
+            .unwrap()
+        })
+        .collect::<Vec<TranitiveDep>>();
+    // let de = serde_json::Deserializer::from_slice(&decompressed);
+    // let mut krates = Vec::new();
+    // for line in pb.wrap_iter(de.into_iter::<TransitiveDep>()) {
+    //     let krate = line?;
+    //     krates.push(krate);
+    // }
+    pb.finish_and_clear();
+
+    krates.par_sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    Ok(krates)
+}
+
+fn create_matchers(search: &str) -> error::Result<Matcher> {
+
+    let mut pieces = search.splitn(2, ':');
+    let matcher = Matcher {
+        name: pieces.next().unwrap(),
+        req: match pieces.next().unwrap_or("*").parse() {
+            Ok(req) => req,
+            Err(err) => return Err(error::Error::ParseSeries(search.to_string(), err)),
+        },
+        nodes: Vec::new(),
+    };
+
+    Ok(matcher)
+}
+
+fn matching_crates(krate: &TranitiveDep, search: &[String]) -> bool {
+    search.iter()
+        .map(|s| create_matchers(s).expect("failed to parse"))
+        .any(|matcher| matcher.name == krate.name && matcher.req.matches(&krate.version))
+}
+
+fn draw_graph2(args: &Args, table: &[TranitiveDep]) {
+    let mut colors = Vec::new();
+    let mut captions = Vec::new();
+    let primary: palette::Color = Srgb::new(217u8, 87, 43).into_format().into_linear().into();
+    let n = args.crates.len();
+    for i in 0..n {
+        let linear = primary.shift_hue(360.0 * ((i + 1) as f32) / (n as f32));
+        let srgb = Srgb::from_linear(linear.into()).into_format::<u8>();
+        let hex = format!("#{:02X}{:02X}{:02X}", srgb.red, srgb.green, srgb.blue);
+        colors.push(hex);
+        captions.push(args.crates[i].replace('_', "\\\\_"));
+    }
+
+    let mut fg = Figure::new();
+    {
+        // Create plot
+        let axes = fg.axes2d();
+        axes.set_title(&args.title.as_ref().unwrap().replace('_', "\\\\_"), &[]);
+        axes.set_x_range(
+            Fix(float_year(&table[0].timestamp) - 0.3),
+            Fix(float_year(&Utc::now()) + 0.15),
+        );
+        axes.set_y_range(Fix(0.0), Auto);
+        axes.set_x_ticks(Some((Fix(1.0), 12)), &[MajorScale(2.0)], &[]);
+        axes.set_legend(
+            Graph(0.05),
+            Graph(0.9),
+            &[Placement(AlignLeft, AlignTop)],
+            &[],
+        );
+
+        // Create x-axis
+        let mut x = Vec::new();
+        for row in table {
+            x.push(float_year(&row.timestamp));
+        }
+
+        // Create series
+        for i in 0..n {
+            if args.relative {
+                let mut y = Vec::new();
+
+                for row in table {
+                    let counts = if args.transitive { row.transitive_count } else { row.direct_count };
+                    y.push(counts as f32 / row.total as f32);
+                }
+                axes.lines(
+                    &x,
+                    &y,
+                    &[Caption(&captions[i]), LineWidth(1.5), Color(&colors[i])],
+                );
+            } else {
+                let mut y = Vec::new();
+                for row in table {
+                    let counts = if args.transitive { row.transitive_count } else { row.direct_count };
+                    y.push(counts);
+                }
+                axes.lines(
+                    &x,
+                    &y,
+                    &[Caption(&captions[i]), LineWidth(1.5), Color(&colors[i])],
+                );
+            }
+        }
+    }
+    fg.show();
+}
+fn float_year(dt: &DateTime) -> f64 {
+    let nd = NaiveDate::from_ymd(2017, 1, 1);
+    let nt = NaiveTime::from_hms_milli(0, 0, 0, 0);
+    let base = DateTime::from_utc(NaiveDateTime::new(nd, nt), Utc);
+    let offset = dt.signed_duration_since(base);
+    let year = offset.num_minutes() as f64 / 525_960.0 + 2017.0;
+    year
+}
+
+pub(crate) fn tally2(args: &Args) -> error::Result<()> {
+    // TODO prgressBar needs to have an actual len
+    let pb = ProgressBar::new(139_079);
+    pb.set_message("FIX ME");
+
+    let table = load_computed(&pb)?
+        .into_par_iter()
+        .filter(|k| matching_crates(k, &args.crates))
+        .collect::<Vec<_>>();
+    
+    draw_graph2(args, table.as_ref());
+    Ok(())
+}

--- a/src/tally2.rs
+++ b/src/tally2.rs
@@ -84,6 +84,17 @@ fn matching_crates(krate: &TransitiveDep, search: &[String]) -> bool {
         .any(|matcher| matcher.name == krate.name && matcher.req.matches(&krate.version))
 }
 
+fn version_match(ver: &str, row: &TransitiveDep) -> bool {
+    if let Some(ver) = ver.split(':').nth(1) {
+        let pin_req = format!("^{}", ver);
+        let ver_req = VersionReq::parse(&pin_req).expect("version match");
+        ver_req.matches(&row.version)
+    } else {
+        println!("SHOULD NOT SEE FOR NOW");
+        true
+    }
+}
+
 fn draw_graph2(args: &Args, table: &[TransitiveDep]) {
     let mut colors = Vec::new();
     let mut captions = Vec::new();
@@ -119,8 +130,10 @@ fn draw_graph2(args: &Args, table: &[TransitiveDep]) {
             let mut y = Vec::new();
             let mut x = Vec::new();
             for row in table {
-                x.push(float_year(&row.timestamp));
-                y.push(row.transitive_count);
+                if version_match(&args.crates[i], row) {
+                    x.push(float_year(&row.timestamp));
+                    y.push(row.transitive_count);
+                }
             }
             axes.lines(
                 &x,


### PR DESCRIPTION
I was trying to push up to ask what you thought of this
```rust
// the is inside process_event after removing found crates and pinning version numbers

// this could probably be a FnvHashSet instead might save a few iterations
let mut to_update = Vec::new();

let index = self.crates.entry(event.name).or_insert_with(Vec::new).len();
let key = CrateKey::new(event.name, index as u32);

// the updated crates dep's and trans dep's from Resolve::add_crate 
// passed along from resolve_and_add_to_graph
let trans_res = self.resolve_and_add_to_graph(key, &metadata);
to_update.extend(trans_res.crates.keys());

self.reverse_depends.insert(key, Set::default());
self.crates.get_mut(&event.name).unwrap().push(metadata);

for outdated in redo.iter() {
    let metadata = self.crates[&outdated.name][outdated.index as usize].clone();
    warn!("re-resolving {} {}", outdated.name, metadata.num);

    // do I need to also recheck the redo crates??
    let re_res = self.resolve_and_add_to_graph(*outdated, &metadata);
    to_update.extend(re_res.crates.keys());
}
// returns only the updated crates to re count transitive deps at every
// time point they changed
to_update
```
so I'm only looping over crates that I have to recount because of update right? If this is the way to
do it it's been running for 3 days and is at 50%, I also ran this on the first 2 months of  the crates.io index and got 3 million unique events??