### PR TITLE
Fix transitivity of separator agnostic comparison

### DIFF
--- a/src/cratename.rs
+++ b/src/cratename.rs
@@ -89,10 +89,9 @@ struct SeparatorAgnosticByte(u8);
 
 impl Ord for SeparatorAgnosticByte {
     fn cmp(&self, rhs: &Self) -> Ordering {
-        match (self.0, rhs.0) {
-            (b'-', b'_') | (b'_', b'-') => Ordering::Equal,
-            (lhs, rhs) => lhs.cmp(&rhs),
-        }
+        let lhs = if self.0 == b'_' { b'-' } else { self.0 };
+        let rhs = if rhs.0 == b'_' { b'-' } else { rhs.0 };
+        lhs.cmp(&rhs)
     }
 }
 


### PR DESCRIPTION
The previous definition of this `Ord` impl violated transitivity, which could manifest as lookup failures in a BTreeMap.

```rust
#[test]
fn test_broken_transitive() {
    let proc_macro_rules = CrateNameQuery::ref_cast("proc-macro-rules");
    let proc_macro2 = CrateNameQuery::ref_cast("proc-macro2");
    let proc_macro_helper = CrateNameQuery::ref_cast("proc_macro_helper");
 
    assert!(proc_macro_rules < proc_macro2);
    assert!(proc_macro2 < proc_macro_helper);
    assert!(proc_macro_helper < proc_macro_rules);
}
```