### PR TITLE
Truncate decimal precision in data table in relative mode

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -2,6 +2,7 @@ use crate::total::Total;
 use anyhow::Result;
 use cargo_tally::matrix::Matrix;
 use cargo_tally::timestamp::NaiveDateTime;
+use std::cmp;
 use std::env;
 use std::fmt::{self, Display};
 use std::fs;
@@ -94,7 +95,7 @@ impl<'a> Display for Row<'a> {
                 formatter.write_str("0")?;
             } else {
                 let fraction = self.1 as f32 / total as f32;
-                write!(formatter, "{}", fraction)?;
+                write_truncated(formatter, fraction)?;
             }
         } else {
             write!(formatter, "{}", self.1)?;
@@ -102,4 +103,16 @@ impl<'a> Display for Row<'a> {
         formatter.write_str("},\n")?;
         Ok(())
     }
+}
+
+fn write_truncated(formatter: &mut fmt::Formatter, fraction: f32) -> fmt::Result {
+    let mut repr = fraction.to_string();
+    let nonzero_digit = |ch: char| ch >= '1' && ch <= '9';
+    if let Some(first_nonzero) = repr.find(nonzero_digit) {
+        repr.truncate(cmp::min(first_nonzero + 4, repr.len()));
+    }
+    if let Some(last_nonzero) = repr.rfind(nonzero_digit) {
+        repr.truncate(last_nonzero + 1);
+    }
+    formatter.write_str(&repr)
 }


### PR DESCRIPTION
Anything more than 4 digits is irrelevant precision and blows up the size of the generated html files.

Before:

```json
        {"time":1427016581706, "edges":0.00064935064},
        {"time":1427052848772, "edges":0.0012953368},
        {"time":1427053035576, "edges":0.0019417476},
        {"time":1427053122107, "edges":0.0025873221},
        {"time":1427053199509, "edges":0.003232062},
        {"time":1427053302708, "edges":0.003875969},
        {"time":1427053391607, "edges":0.0045190444},
        {"time":1427053505233, "edges":0.0051612905},
        {"time":1427053575274, "edges":0.0058027077},
```

After:

```json
        {"time":1427016581706, "edges":0.0006493},
        {"time":1427052848772, "edges":0.001295},
        {"time":1427053035576, "edges":0.001941},
        {"time":1427053122107, "edges":0.002587},
        {"time":1427053199509, "edges":0.003232},
        {"time":1427053302708, "edges":0.003875},
        {"time":1427053391607, "edges":0.004519},
        {"time":1427053505233, "edges":0.005161},
        {"time":1427053575274, "edges":0.005802},
```