### PR TITLE
Update to clap 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ atty = "0.2"
 anyhow = "1.0"
 bytesize = "1.0"
 chrono = "0.4"
-clap = "3.0"
+clap = "3.1"
 db-dump = "0.3.1"
 differential-dataflow = { version = "0.12", default-features = false }
 minipre = "0.2"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 use crate::{cratename, user};
-use clap::{App, Arg};
+use clap::{Arg, Command};
 use regex::Regex;
 use semver::VersionReq;
 use std::env;
@@ -36,8 +36,8 @@ OPTIONS:
 {options}\
 ";
 
-fn app(jobs_help: &str) -> App {
-    let mut app = App::new("cargo-tally")
+fn app(jobs_help: &str) -> Command {
+    let mut app = Command::new("cargo-tally")
         .override_usage(USAGE)
         .help_template(TEMPLATE)
         .arg(arg_db())


### PR DESCRIPTION
There are several deprecations in this release:
https://github.com/clap-rs/clap/releases/tag/v3.1.0