### PR TITLE
Add serde impls for compatibility with timely's bincode feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ opener = "0.5"
 ref-cast = "1.0"
 regex = "1.5"
 semver = "1.0"
+serde = "1.0"
 sysinfo = { version = "0.23", default-features = false }
 termcolor = "1.1"
 thiserror = "1.0"

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -18,6 +18,24 @@ macro_rules! do_not_abomonate {
                 unimplemented!("unexpected abomonation extent");
             }
         }
+
+        impl $(<$param>)? serde::Serialize for $($path)::+ $(<$param>)? $(where $($clause)*)? {
+            fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                unimplemented!("unexpected serde serialize");
+            }
+        }
+
+        impl<'de, $($param)?> serde::Deserialize<'de> for $($path)::+ $(<$param>)? $(where $($clause)*)? {
+            fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                unimplemented!("unexpected serde deserialize");
+            }
+        }
     };
 }
 


### PR DESCRIPTION
Otherwise cargo-tally fails to compile when `timely/bincode` is enabled.

```console
error[E0277]: the trait bound `for<'a> lib::timestamp::NaiveDateTime: serde::de::Deserialize<'a>` is not satisfied
  --> src/timestamp.rs:48:6
   |
48 | impl Timestamp for NaiveDateTime {
   |      ^^^^^^^^^ the trait `for<'a> serde::de::Deserialize<'a>` is not implemented for `lib::timestamp::NaiveDateTime`
   |
note: required by a bound in `timely::progress::Timestamp`
  --> github.com-1ecc6299db9ec823/timely-0.12.0/src/progress/timestamp.rs:12:59
   |
12 | pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+Data+Hash+Ord {
   |                                                           ^^^^ required by this bound in `timely::progress::Timestamp`

error[E0277]: the trait bound `lib::timestamp::NaiveDateTime: serde::ser::Serialize` is not satisfied
  --> src/timestamp.rs:48:6
   |
48 | impl Timestamp for NaiveDateTime {
   |      ^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `lib::timestamp::NaiveDateTime`
   |
note: required by a bound in `timely::progress::Timestamp`
  --> github.com-1ecc6299db9ec823/timely-0.12.0/src/progress/timestamp.rs:12:59
   |
12 | pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+Data+Hash+Ord {
   |                                                           ^^^^ required by this bound in `timely::progress::Timestamp`

error[E0277]: the trait bound `for<'a> lib::timestamp::NaiveDateTime: serde::de::Deserialize<'a>` is not satisfied
   --> src/timestamp.rs:88:6
    |
88  | impl Refines<()> for NaiveDateTime {
    |      ^^^^^^^^^^^ the trait `for<'a> serde::de::Deserialize<'a>` is not implemented for `lib::timestamp::NaiveDateTime`
    |
note: required by a bound in `Refines`
   --> github.com-1ecc6299db9ec823/timely-0.12.0/src/progress/timestamp.rs:114:39
    |
114 |     pub trait Refines<T: Timestamp> : Timestamp {
    |                                       ^^^^^^^^^ required by this bound in `Refines`

error[E0277]: the trait bound `lib::timestamp::NaiveDateTime: serde::ser::Serialize` is not satisfied
   --> src/timestamp.rs:88:6
    |
88  | impl Refines<()> for NaiveDateTime {
    |      ^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `lib::timestamp::NaiveDateTime`
    |
note: required by a bound in `Refines`
   --> github.com-1ecc6299db9ec823/timely-0.12.0/src/progress/timestamp.rs:114:39
    |
114 |     pub trait Refines<T: Timestamp> : Timestamp {
    |                                       ^^^^^^^^^ required by this bound in `Refines`
```