### PR TITLE
Use clap's TypedValueParser impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ chrono = "0.4"
 clap = { version = "3.2.5", features = ["deprecated"] }
 db-dump = "0.3.1"
 differential-dataflow = { version = "0.12", default-features = false }
-ghost = "0.1"
 minipre = "0.2"
 num_cpus = "1.0"
 once_cell = "1.8"


### PR DESCRIPTION
The TypedValueParser impls in clap use private APIs to produce a nicer message.

Before:

```console
$ cargo tally --jobs x
error: invalid digit found in string
```

After:

```console
$ cargo tally --jobs x
error: Invalid value "x" for '--jobs <N>': invalid digit found in string

For more information try --help
```