### PR TITLE
Fix clap contains_id -> get_flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -100,8 +100,8 @@ pub(crate) fn parse() -> Opt {
 
     let title = matches.get_one::<String>(TITLE).map(String::clone);
 
-    let relative = matches.contains_id(RELATIVE);
-    let transitive = matches.contains_id(TRANSITIVE);
+    let relative = matches.get_flag(RELATIVE);
+    let transitive = matches.get_flag(TRANSITIVE);
 
     let queries = matches
         .get_many::<String>(QUERIES)


### PR DESCRIPTION
In clap 3, `contains_id` returns whether a flag is present in the command line arguments, and false if it wasn't, even if a flag with that flag name was registered on the clap app. In clap 4, `contains_id` always returns true for a flag name that has been registered on the clap app, and `get_flag` must be used to tell whether it is present in the command line arguments.