### PR TITLE
Replace SipHash with FNV hash for TypeId map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["deprecated"] }
 db-dump = "0.4"
 differential-dataflow = { version = "0.12", default-features = false }
+fnv = "1.0.7"
 is-terminal = "0.4"
 minipre = "0.2"
 num_cpus = "1.0"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1,6 +1,6 @@
+use fnv::FnvHashMap;
 use once_cell::sync::OnceCell;
 use std::any::TypeId;
-use std::collections::HashMap as Map;
 use std::fmt::{self, Debug};
 use std::iter::{Copied, FromIterator};
 use std::slice::Iter;
@@ -69,7 +69,7 @@ where
             return Slice::EMPTY;
         }
 
-        static ARENA: OnceCell<Mutex<Map<TypeId, Box<dyn Send>>>> = OnceCell::new();
+        static ARENA: OnceCell<Mutex<FnvHashMap<TypeId, Box<dyn Send>>>> = OnceCell::new();
 
         let mut map = ARENA
             .get_or_init(Mutex::default)


### PR DESCRIPTION
SipHash is relatively slow for small keys. FNV is optimize for short keys, such as individual integers (which TypeId hashes as).