### PR TITLE
Replace once_cell crate with standard library's OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ differential-dataflow = { version = "0.12", default-features = false }
 fnv = "1.0.7"
 minipre = "0.2"
 num_cpus = "1.0"
-once_cell = "1.8"
 opener = "0.6"
 ref-cast = "1.0"
 regex = { version = "1.9.2", default-features = false, features = ["std", "perf"] }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1,9 +1,9 @@
 use fnv::FnvHashMap;
-use once_cell::sync::OnceCell;
 use std::any::TypeId;
 use std::fmt::{self, Debug};
 use std::iter::{Copied, FromIterator};
 use std::slice::Iter;
+use std::sync::OnceLock;
 use std::sync::{Mutex, PoisonError};
 use typed_arena::Arena;
 
@@ -69,7 +69,7 @@ where
             return Slice::EMPTY;
         }
 
-        static ARENA: OnceCell<Mutex<FnvHashMap<TypeId, Box<dyn Send>>>> = OnceCell::new();
+        static ARENA: OnceLock<Mutex<FnvHashMap<TypeId, Box<dyn Send>>>> = OnceLock::new();
 
         let mut map = ARENA
             .get_or_init(Mutex::default)


### PR DESCRIPTION
Available since Rust 1.70.