### PR TITLE
Fill in an unused CrateId for deleted crates

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -140,6 +140,8 @@ pub(crate) fn load(path: impl AsRef<Path>) -> Result<(DbDump, CrateMap)> {
         })
         .load(path)?;
 
+    crate::mend::mend_crates(&mut crates);
+
     let mut feature_names = mem::take(&mut *feature_names.borrow_mut());
     let mut feature_buffer = Vec::new();
     for (release, mut features) in releases.iter_mut().zip(release_features) {
@@ -196,7 +198,7 @@ pub(crate) fn load(path: impl AsRef<Path>) -> Result<(DbDump, CrateMap)> {
     crates.users = users;
     crates.users.extend(teams);
 
-    crate::mend::mend(&mut db_dump, &crates);
+    crate::mend::mend_releases(&mut db_dump, &crates);
 
     Ok((db_dump, crates))
 }


### PR DESCRIPTION
The code previously assumed that only releases were being deleted, and that a crate with the right ID would still exist.

https://github.com/dtolnay/cargo-tally/blob/e82e2454835fec13bea44369769d0a8cb9e18eb7/src/mend.rs#L83

Recently crates.io has begun deleting crates outright, such that their crate-id no longer exists in the crates.csv table. Even if some other crate still depends on the deleted one…