### PR TITLE
Unbreak xbi-channel-primitives dependency on xcm

### DIFF
--- a/src/mend.rs
+++ b/src/mend.rs
@@ -20,6 +20,8 @@ pub(crate) fn mend_crates(crates: &mut CrateMap) {
         "quickcheck",
         "tokio-core",
         "tokio-io",
+        "xcm",
+        "xcm-executor",
     ] {
         if crates.id(crate_name).is_none() {
             while crates.name(next_crate_id).is_some() {
@@ -756,6 +758,30 @@ pub(crate) fn mend_releases(db_dump: &mut DbDump, crates: &CrateMap) {
                 kind: DependencyKind::Normal,
             });
             release
+        });
+    }
+
+    {
+        let crate_id = crates.id("xcm").unwrap();
+
+        push_release(Release {
+            id: next_version_id(),
+            crate_id,
+            num: version!(0.0.0),
+            created_at: datetime!(9 Mar 2021 05:51:34),
+            features: Slice::EMPTY,
+        });
+    }
+
+    {
+        let crate_id = crates.id("xcm-executor").unwrap();
+
+        push_release(Release {
+            id: next_version_id(),
+            crate_id,
+            num: version!(0.0.0),
+            created_at: datetime!(9 Mar 2021 06:21:39),
+            features: Slice::EMPTY,
         });
     }
 }


### PR DESCRIPTION
Version 0.3.1 of `xbi-channel-primitives` depends on `xcm`:

```toml
[package]
name        = "xbi-channel-primitives"
version     = "0.3.1"

[dependencies]
xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false, optional = true, version = "0" }
#...
```

but `xcm` has recently been deleted from crates.io, breaking cargo-tally:

```console
error: xbi-channel-primitives v0.3.1 depends on xcm which is not found
```

The data for the mended releases in this PR is from:

- https://github.com/rust-lang/crates.io-index-archive/commit/f854b529b7535ce5555208b10acc5a65ca980687
- https://github.com/rust-lang/crates.io-index-archive/commit/19a7812bb3bce460e621b5c6f1afe21c57a3a89e