### PR TITLE
Use jemalloc allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,8 @@ thiserror = "1.0"
 timely-master = { version = "=0.13.0-dev.1", default-features = false }
 typed-arena = "2.0"
 
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
I measured this being a little bit faster, but not enough to be worthwhile, I think. For something like `cargo tally syn`, the difference between 50 seconds vs 45 seconds.