### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -43,11 +43,11 @@ where
             }
         }
 
-        self.alloc.alloc(layout)
+        unsafe { self.alloc.alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        self.alloc.dealloc(ptr, layout);
+        unsafe { self.alloc.dealloc(ptr, layout) };
 
         let size = layout.size() as u64;
         self.current.fetch_sub(size, Ordering::Relaxed);
@@ -70,16 +70,16 @@ where
             }
         }
 
-        self.alloc.alloc_zeroed(layout)
+        unsafe { self.alloc.alloc_zeroed(layout) }
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
         self.count.fetch_add(1, Ordering::Relaxed);
 
         let align = old_layout.align();
-        let new_layout = Layout::from_size_align_unchecked(new_size, align);
+        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, align) };
 
-        let new_ptr = self.alloc.realloc(ptr, old_layout, new_size);
+        let new_ptr = unsafe { self.alloc.realloc(ptr, old_layout, new_size) };
         let old_size = old_layout.size() as u64;
         let new_size = new_size as u64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::arc_with_non_send_sync, // https://github.com/rust-lang/rust-clippy/issues/11076

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_upper_case_globals)]
 #![allow(
     clippy::cast_lossless,


### PR DESCRIPTION
This lint is allow-by-default for now in 2021 edition, but is going to become warn-by-default in 2024 edition.