### PR TITLE
Disregard a known broken dependency

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -141,6 +141,8 @@ pub(crate) fn load(path: impl AsRef<Path>) -> Result<(DbDump, CrateMap)> {
 
     crate::mend::mend_crates(&mut crates);
 
+    let known_broken = [(crates.id("modbus"), &Version::new(0, 1, 0), "test-server")];
+
     let mut feature_names = mem::take(&mut *feature_names.borrow_mut());
     let mut feature_buffer = Vec::new();
     for (release, mut features) in releases.iter_mut().zip(release_features) {
@@ -159,6 +161,12 @@ pub(crate) fn load(path: impl AsRef<Path>) -> Result<(DbDump, CrateMap)> {
                         crates.id(name)
                     } {
                         crate_id
+                    } else if known_broken.contains(&(
+                        Some(release.crate_id),
+                        &release.num,
+                        feature_names.name(feature_id),
+                    )) {
+                        release.crate_id
                     } else {
                         bail!(
                             "{} v{} depends on {} which is not found",

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,6 +8,12 @@ use std::str::FromStr;
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Version(pub semver::Version);
 
+impl Version {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Version(semver::Version::new(major, minor, patch))
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct VersionReq {
     pub comparators: Slice<Comparator>,


### PR DESCRIPTION
https://docs.rs/crate/modbus/0.1.0/source/Cargo.toml

The `test-server` crate has never appeared in https://github.com/rust-lang/crates.io-index, and did not used to be reported by crates.io in db-dump.tar.gz. It recently started appearing, which causes:

```console
error: modbus v0.1.0 depends on test-server which is not found
```