### PR TITLE
Change allocator to return null instead of abort

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,5 +1,5 @@
 use bytesize::ByteSize;
-use std::alloc::{self, GlobalAlloc, Layout, System};
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::fmt::{self, Display};
 use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -44,7 +44,7 @@ where
 
         if let Some(limit) = LIMIT {
             if peak > limit {
-                alloc::handle_alloc_error(layout);
+                return ptr::null_mut();
             }
         }
 
@@ -71,7 +71,7 @@ where
 
         if let Some(limit) = LIMIT {
             if peak > limit {
-                alloc::handle_alloc_error(layout);
+                return ptr::null_mut();
             }
         }
 
@@ -81,13 +81,10 @@ where
     unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
         self.count.fetch_add(1, Ordering::Relaxed);
 
-        let align = old_layout.align();
-        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, align) };
-
         if let Some(limit) = LIMIT {
             let current = self.current.load(Ordering::Relaxed);
             if current + new_size as u64 > limit {
-                alloc::handle_alloc_error(new_layout);
+                return ptr::null_mut();
             }
         }
 


### PR DESCRIPTION
This has the same end effect of aborting, it's just the caller's responsibility to call `handle_alloc_error` in response to null.

```console
memory allocation of 8192 bytes failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```